### PR TITLE
codex/feature/carga-claves-nvs

### DIFF
--- a/sistema-alarma-vehicular/firmware/auto/main/app_vehiculo.c
+++ b/sistema-alarma-vehicular/firmware/auto/main/app_vehiculo.c
@@ -81,14 +81,17 @@ static const sensor_config_t __attribute__((unused)) SENSOR_CONFIG_DEFAULT = {
  */
 static esp_err_t vehiculo_init_nvs(void)
 {
-    esp_err_t ret = nvs_flash_init();
+    esp_err_t ret = nvs_flash_secure_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_secure_init();
+    }
+    if (ret == ESP_ERR_NOT_SUPPORTED) {
         ret = nvs_flash_init();
     }
     ESP_ERROR_CHECK(ret);
-    
-    ESP_LOGI(TAG, "NVS inicializado correctamente");
+
+    ESP_LOGI(TAG, "NVS seguro inicializado correctamente");
     return ESP_OK;
 }
 

--- a/sistema-alarma-vehicular/firmware/compartido/include/cripto_utils.h
+++ b/sistema-alarma-vehicular/firmware/compartido/include/cripto_utils.h
@@ -34,6 +34,7 @@ typedef struct {
 // Inicialización del subsistema criptográfico
 esp_err_t cripto_init(void);
 esp_err_t cripto_cargar_claves_efuse(void);
+esp_err_t cripto_cargar_claves_nvs(void);
 
 // Funciones AES-CTR
 esp_err_t aes_ctr_cifrar(const uint8_t* plaintext, size_t len, 

--- a/sistema-alarma-vehicular/firmware/compartido/src/cripto_utils.c
+++ b/sistema-alarma-vehicular/firmware/compartido/src/cripto_utils.c
@@ -2,6 +2,9 @@
 #include "protocolo_seguro.h"  // Para ROLLING_CODE_SIZE
 #include "esp_efuse.h"
 #include "esp_hmac.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include "mbedtls/md.h"
 #include "esp_random.h"
 #include "esp_timer.h"
 #include "mbedtls/aes.h"
@@ -45,6 +48,36 @@ esp_err_t cripto_cargar_claves_efuse(void) {
     }
 }
 
+esp_err_t cripto_cargar_claves_nvs(void) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open("secure_keys", NVS_READONLY, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    size_t tam = AES_128_KEY_SIZE;
+    ret = nvs_get_blob(handle, "aes", ctx_cripto.clave_aes, &tam);
+    if (ret != ESP_OK || tam != AES_128_KEY_SIZE) {
+        nvs_close(handle);
+        ESP_LOGE(TAG, "Error leyendo clave AES: %s", esp_err_to_name(ret));
+        return (ret == ESP_OK) ? ESP_ERR_INVALID_SIZE : ret;
+    }
+
+    tam = HMAC_SHA256_SIZE;
+    ret = nvs_get_blob(handle, "hmac", ctx_cripto.clave_hmac, &tam);
+    nvs_close(handle);
+    if (ret != ESP_OK || tam != HMAC_SHA256_SIZE) {
+        ESP_LOGE(TAG, "Error leyendo clave HMAC: %s", esp_err_to_name(ret));
+        return (ret == ESP_OK) ? ESP_ERR_INVALID_SIZE : ret;
+    }
+
+    ctx_cripto.claves_cargadas = true;
+    ctx_cripto.contador_uso = 0;
+    ESP_LOGI(TAG, "Claves cargadas desde NVS");
+    return ESP_OK;
+}
+
 esp_err_t aes_ctr_cifrar(const uint8_t* plaintext, size_t len, 
                         const uint8_t* nonce, uint8_t* ciphertext) {
     if (!ctx_cripto.claves_cargadas) {
@@ -54,17 +87,8 @@ esp_err_t aes_ctr_cifrar(const uint8_t* plaintext, size_t len,
     mbedtls_aes_context aes;
     mbedtls_aes_init(&aes);
     
-    // Usar clave desde eFuse BLK3
-    uint8_t clave_aes[AES_128_KEY_SIZE];
-    esp_err_t ret = esp_efuse_read_block(EFUSE_BLK_KEY3, clave_aes, 0, AES_128_KEY_SIZE * 8);
-    if (ret != ESP_OK) {
-        mbedtls_aes_free(&aes);
-        return ret;
-    }
-    
-    int mbedtls_ret = mbedtls_aes_setkey_enc(&aes, clave_aes, 128);
+    int mbedtls_ret = mbedtls_aes_setkey_enc(&aes, ctx_cripto.clave_aes, 128);
     if (mbedtls_ret != 0) {
-        limpiar_memoria_segura(clave_aes, AES_128_KEY_SIZE);
         mbedtls_aes_free(&aes);
         return ESP_ERR_INVALID_ARG;
     }
@@ -80,7 +104,6 @@ esp_err_t aes_ctr_cifrar(const uint8_t* plaintext, size_t len,
                                        stream_block, plaintext, ciphertext);
     
     // Limpiar secretos
-    limpiar_memoria_segura(clave_aes, AES_128_KEY_SIZE);
     limpiar_memoria_segura(counter_block, 16);
     limpiar_memoria_segura(stream_block, 16);
     mbedtls_aes_free(&aes);
@@ -101,13 +124,25 @@ esp_err_t hmac_calcular(const uint8_t* data, size_t len, uint8_t* hmac_out) {
         return ESP_ERR_INVALID_STATE;
     }
     
-    // Usar periférico HMAC con clave en eFuse BLK4
-    esp_err_t ret = esp_hmac_calculate(HMAC_KEY_ID_4, data, len, hmac_out);
-    if (ret == ESP_OK) {
-        ctx_cripto.contador_uso++;
+    mbedtls_md_context_t md_ctx;
+    const mbedtls_md_info_t* info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    mbedtls_md_init(&md_ctx);
+    int ret = mbedtls_md_setup(&md_ctx, info, 1);
+    if (ret != 0) {
+        mbedtls_md_free(&md_ctx);
+        return ESP_FAIL;
     }
-    
-    return ret;
+
+    ret = mbedtls_md_hmac_starts(&md_ctx, ctx_cripto.clave_hmac, HMAC_SHA256_SIZE);
+    if (ret == 0) ret = mbedtls_md_hmac_update(&md_ctx, data, len);
+    if (ret == 0) ret = mbedtls_md_hmac_finish(&md_ctx, hmac_out);
+    mbedtls_md_free(&md_ctx);
+
+    if (ret == 0) {
+        ctx_cripto.contador_uso++;
+        return ESP_OK;
+    }
+    return ESP_FAIL;
 }
 
 esp_err_t hmac_verificar(const uint8_t* data, size_t len, const uint8_t* hmac_esperado) {

--- a/sistema-alarma-vehicular/firmware/compartido/src/protocolo_seguro.c
+++ b/sistema-alarma-vehicular/firmware/compartido/src/protocolo_seguro.c
@@ -29,10 +29,10 @@ esp_err_t protocolo_init(void) {
         return ret;
     }
     
-    // Cargar claves desde eFuse
-    ret = cripto_cargar_claves_efuse();
+    // Cargar claves desde NVS seguro
+    ret = cripto_cargar_claves_nvs();
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Error cargando claves eFuse: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "Error cargando claves NVS: %s", esp_err_to_name(ret));
         return ret;
     }
     

--- a/sistema-alarma-vehicular/firmware/llave/main/main.c
+++ b/sistema-alarma-vehicular/firmware/llave/main/main.c
@@ -44,9 +44,12 @@ void app_main(void)
     }
 
     // Inicialización básica del sistema
-    esp_err_t ret = nvs_flash_init();
+    esp_err_t ret = nvs_flash_secure_init();
     if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_secure_init();
+    }
+    if (ret == ESP_ERR_NOT_SUPPORTED) {
         ret = nvs_flash_init();
     }
     ESP_ERROR_CHECK(ret);

--- a/sistema-alarma-vehicular/herramientas/configuracion/generar_claves.py
+++ b/sistema-alarma-vehicular/herramientas/configuracion/generar_claves.py
@@ -8,6 +8,8 @@ import os
 import sys
 import secrets
 import hashlib
+import tempfile
+import subprocess
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 import argparse
@@ -65,6 +67,23 @@ def guardar_claves_archivo(dispositivo_id, clave_aes, clave_hmac, directorio='cl
         f.write(f"Clave HMAC (hex): {clave_hmac.hex()}\n")
         f.write(f"Timestamp generación: {hash(os.urandom(8))}\n")
 
+def escribir_claves_nvs(dispositivo_id, clave_aes, clave_hmac, directorio='claves'):
+    """Genera una imagen NVS con las claves"""
+    os.makedirs(directorio, exist_ok=True)
+
+    csv_path = os.path.join(directorio, f'nvs_{dispositivo_id}.csv')
+    bin_path = os.path.join(directorio, f'nvs_{dispositivo_id}.bin')
+
+    with open(csv_path, 'w') as f:
+        f.write('namespace,secure_keys\n')
+        f.write(f'aes,data,hex2bin,{clave_aes.hex()}\n')
+        f.write(f'hmac,data,hex2bin,{clave_hmac.hex()}\n')
+
+    try:
+        subprocess.run(['nvs_partition_gen.py', csv_path, bin_path, '0x1000'], check=True)
+    finally:
+        os.remove(csv_path)
+
 def generar_lote_dispositivos(cantidad, prefijo='DEV'):
     """
     Genera claves para múltiples dispositivos
@@ -78,6 +97,7 @@ def generar_lote_dispositivos(cantidad, prefijo='DEV'):
         dispositivo_id = f"{prefijo}{i:04d}"
         clave_aes, clave_hmac = generar_claves_dispositivo(dispositivo_id, clave_maestra)
         guardar_claves_archivo(dispositivo_id, clave_aes, clave_hmac)
+        escribir_claves_nvs(dispositivo_id, clave_aes, clave_hmac)
         print(f"  ✓ {dispositivo_id}")
     
     # Guardar clave maestra
@@ -98,6 +118,7 @@ def main():
         # Generar para un dispositivo
         clave_aes, clave_hmac = generar_claves_dispositivo(args.dispositivo)
         guardar_claves_archivo(args.dispositivo, clave_aes, clave_hmac)
+        escribir_claves_nvs(args.dispositivo, clave_aes, clave_hmac)
         print(f"Claves generadas para {args.dispositivo}")
         print(f"AES: {clave_aes.hex()}")
         print(f"HMAC: {clave_hmac.hex()}")


### PR DESCRIPTION
## Summary
- load AES/HMAC keys from encrypted NVS namespace
- use new function in protocolo_seguro
- initialize NVS with secure init in vehiculo and llave apps
- output NVS partition image with generar_claves.py

## Testing
- `python3 -m py_compile herramientas/configuracion/generar_claves.py`

------
https://chatgpt.com/codex/tasks/task_b_6889615f3148832885e436cdd0d37e96